### PR TITLE
enalbed bulk analysis to run on down-sampling cells

### DIFF
--- a/R/bulk_downsampling_DGEanalysis.r
+++ b/R/bulk_downsampling_DGEanalysis.r
@@ -17,7 +17,7 @@
 bulk_downsampling_DGEanalysis <- function(SCEs,
                                           dataset_names,
                                           celltype_correspondence,
-                                          sampled="individuals",
+                                          sampled = c("individuals", "cells"),
                                           sampleIDs="donor_id",
                                           celltypeIDs="cell_type",
                                           output_path=getwd(),

--- a/R/bulk_power_analysis.r
+++ b/R/bulk_power_analysis.r
@@ -68,13 +68,15 @@ bulk_power_analysis <- function(SCEs,
     gather_celltype_DEGs(celltype_correspondence = celltype_correspondence,
                          pvalue = pvalue,
                          Nperms = Nperms,
-                         output_path = output_path)
+                         output_path = output_path,
+                         sampled = sampled)
 
 
     # Run prop_bulk_DEGs_sc
     prop_bulk_DEGs_sc(bulkDE = bulkDE,
                       output_path = output_path,
                       bulk_cutoff = bulk_cutoff,
-                      pvalue = pvalue)
+                      pvalue = pvalue,
+                      sampled = sampled)
 
 }

--- a/R/downsampling_range.r
+++ b/R/downsampling_range.r
@@ -10,7 +10,7 @@
 #' @return list containing values which the data will be downsampled at, in ascending order
 
 downsampling_range <- function(SCE,
-                               sampled="individuals",
+                               sampled = c("individuals", "cells"),
                                sampleID="Donor.ID"){
 
     # get list of sample IDs
@@ -20,7 +20,7 @@ downsampling_range <- function(SCE,
     numSamples <- length(IDs)
 
     if(sampled=="individuals"){
-        
+
         # want to pick 10 (equally spaced out) sampling points
         range_downsampled <- round(ceiling(seq(from=0,to=numSamples,length.out=12))/5)*5
         range_downsampled <- unique(range_downsampled[2:11])
@@ -41,4 +41,4 @@ downsampling_range <- function(SCE,
 
     return(range_downsampled)
 
-} 
+}

--- a/R/gather_celltype_DEGs.r
+++ b/R/gather_celltype_DEGs.r
@@ -4,17 +4,23 @@
 #' @param pvalue the cut-off p-value used to select DEGs
 #' @param Nperms number of permutations of DGE analysis outputs for each sample
 #' @param output_path path storing the down-sampled DGE analysis for each single-cell dataset, generated for bulk analysis
+#' @param sampled Specifies the unit of down-sampling. Can be either `"individuals"` or `"cells"`, depending on whether the analysis downsamples across samples or cells.
 
 #' Saves combined list of DEGs (across all cell types) in a subdirectory inside the dataset directory
 
 gather_celltype_DEGs <- function(celltype_correspondence,
                                  pvalue=0.05,
                                  Nperms=20,
+                                 sampled = c("individuals", "cells"),
                                  output_path=getwd()){
 
     # validate function input params
     validate_input_parameters_bulk(output_path=output_path, celltype_correspondence=celltype_correspondence,
                                    pvalue=pvalue, Nperms=Nperms)
+
+    # reference the appropriate subdirectory regarding the down-sampling type
+    sampled <- match.arg(sampled)
+    folder_tag <- if (sampled == "cells") "DE_downsampling_cells" else "DE_downsampling"
 
     # loop through datasets
     j <- 0
@@ -29,7 +35,7 @@ gather_celltype_DEGs <- function(celltype_correspondence,
         # loop through each cell type
         for (standard_celltype in names(celltype_correspondence)) {
             # sampling point paths
-            celltype_path <- file.path(base_dataset, standard_celltype, "DE_downsampling")
+            celltype_path <- file.path(base_dataset, standard_celltype, folder_tag)
             downsampled_folders <- list.dirs(celltype_path, recursive=FALSE, full.names=FALSE)
             # loop through sampling points
             for (sample_samples in downsampled_folders) {

--- a/R/prop_bulk_DEGs_sc.r
+++ b/R/prop_bulk_DEGs_sc.r
@@ -13,6 +13,7 @@ utils::globalVariables(c("DEGs","numSamples","pctDEGs"))
 #' @param bulkDE DGE analysis output for a bulk RNA-seq dataset (e.g., `LFSR.tsv`): rows (rownames) should be the genes, columns should be tissues, and entries should be significance levels
 #' @param bulk_cutoff Numeric. Proportion (0–1) of bulk tissues in which a gene must be differentially expressed to be considered (e.g., 0.9 selects DEGs found in ≥90% of tissues).
 #' @param pvalue Numeric. P-value threshold for defining DEGs in the bulk dataset.
+#' @param sampled Specifies the unit of down-sampling. Can be either `"individuals"` or `"cells"`, depending on whether the analysis downsamples across samples or cells.
 #' @param fontsize_axislabels font size for axis labels in plot
 #' @param fontsize_axisticks font size for axis tick labels in plot
 #' @param fontsize_title font size for plot title
@@ -26,6 +27,7 @@ utils::globalVariables(c("DEGs","numSamples","pctDEGs"))
 prop_bulk_DEGs_sc <- function(bulkDE,
                               bulk_cutoff=0.9,
                               pvalue=0.05,
+                              sampled = c("individuals", "cells"),
                               fontsize_axislabels=12,
                               fontsize_axisticks=9,
                               fontsize_title=14,
@@ -114,6 +116,14 @@ prop_bulk_DEGs_sc <- function(bulkDE,
         }
     }
 
+    # specify x-axis label according to the down-sampling style
+    sampled <- match.arg(sampled)
+    x_label <- if (sampled == "cells") {
+        "Number of cells per sample"
+    } else {
+        "Number of samples"
+    }
+
     # create and return plot
     propDEGs_overall.plot <- ggplot(DEGs_df,aes(x=factor(numSamples),y=100*pctDEGs))+
                                     geom_boxplot(outlier.shape=NA,aes(fill=factor(Dataset)),position = position_dodge2(width = 1, preserve = "single"))+
@@ -121,7 +131,7 @@ prop_bulk_DEGs_sc <- function(bulkDE,
                                     guides(fill = guide_legend(label.format = function(x) round(as.numeric(x))))+
                                     theme_cowplot()+
                                     scale_fill_manual(values=generate_color_palette(length(list.dirs(output_path,recursive=F,full.names=F)),palette="Set1"))+
-                                    labs(y="% DEGs", x="Number of Samples", fill="Dataset",title="Percentage DEGs from Bulk data detected when down-sampling scRNA-seq datasets (across all cell types)")+
+                                    labs(y="% DEGs", x=x_label, fill="Dataset",title="Percentage DEGs from Bulk data detected when down-sampling scRNA-seq datasets (across all cell types)")+
                                     scale_alpha(guide = 'none')+
                                     theme(axis.title = element_text(size = fontsize_axislabels),
                                           axis.text.x = element_text(size = fontsize_axisticks),

--- a/man/bulk_downsampling_DGEanalysis.Rd
+++ b/man/bulk_downsampling_DGEanalysis.Rd
@@ -8,7 +8,7 @@ bulk_downsampling_DGEanalysis(
   SCEs,
   dataset_names,
   celltype_correspondence,
-  sampled = "individuals",
+  sampled = c("individuals", "cells"),
   sampleIDs = "donor_id",
   celltypeIDs = "cell_type",
   output_path = getwd(),

--- a/man/downsampling_range.Rd
+++ b/man/downsampling_range.Rd
@@ -4,7 +4,11 @@
 \alias{downsampling_range}
 \title{Obtain the range of values to downsample at (either for individuals, or mean number of cells per individual)}
 \usage{
-downsampling_range(SCE, sampled = "individuals", sampleID = "Donor.ID")
+downsampling_range(
+  SCE,
+  sampled = c("individuals", "cells"),
+  sampleID = "Donor.ID"
+)
 }
 \arguments{
 \item{SCE}{the input data (should be an SCE object)}

--- a/man/gather_celltype_DEGs.Rd
+++ b/man/gather_celltype_DEGs.Rd
@@ -8,6 +8,7 @@ gather_celltype_DEGs(
   celltype_correspondence,
   pvalue = 0.05,
   Nperms = 20,
+  sampled = c("individuals", "cells"),
   output_path = getwd()
 )
 }
@@ -18,8 +19,10 @@ gather_celltype_DEGs(
 
 \item{Nperms}{number of permutations of DGE analysis outputs for each sample}
 
-\item{output_path}{path storing the down-sampled DGE analysis for each single-cell dataset, generated for bulk analysis
+\item{sampled}{Specifies the unit of down-sampling. Can be either \code{"individuals"} or \code{"cells"}, depending on whether the analysis downsamples across samples or cells.
 Saves combined list of DEGs (across all cell types) in a subdirectory inside the dataset directory}
+
+\item{output_path}{path storing the down-sampled DGE analysis for each single-cell dataset, generated for bulk analysis}
 }
 \description{
 Collate DEGs detected in DGE analysis outputs, across all celltypes in a dataset (datasets/DGE analysis outputs should have common celltypes as specified below)

--- a/man/prop_bulk_DEGs_sc.Rd
+++ b/man/prop_bulk_DEGs_sc.Rd
@@ -8,6 +8,7 @@ prop_bulk_DEGs_sc(
   bulkDE,
   bulk_cutoff = 0.9,
   pvalue = 0.05,
+  sampled = c("individuals", "cells"),
   fontsize_axislabels = 12,
   fontsize_axisticks = 9,
   fontsize_title = 14,
@@ -23,6 +24,8 @@ prop_bulk_DEGs_sc(
 \item{bulk_cutoff}{Numeric. Proportion (0–1) of bulk tissues in which a gene must be differentially expressed to be considered (e.g., 0.9 selects DEGs found in ≥90\% of tissues).}
 
 \item{pvalue}{Numeric. P-value threshold for defining DEGs in the bulk dataset.}
+
+\item{sampled}{Specifies the unit of down-sampling. Can be either \code{"individuals"} or \code{"cells"}, depending on whether the analysis downsamples across samples or cells.}
 
 \item{fontsize_axislabels}{font size for axis labels in plot}
 


### PR DESCRIPTION
- Added the sampled = c("individuals", "cells") argument to gather_celltype_DEGs() and used a folder_tag internally to reference the appropriate subdirectory. 
- Added the sampled = c("individuals", "cells") argument to prob_bulk_DEGs_sc() and used a x_lable tag to adjust x-axis label according to the down-sampling options.
Bulk analysis can run on down-sampling cells after the fix and generate the expected output plot.
